### PR TITLE
Add AI Chatbot API key article

### DIFF
--- a/articles/buildfire-ai-chatbot-openai.html
+++ b/articles/buildfire-ai-chatbot-openai.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BuildFire AI Chatbot API Key Setup | PixelPlugins</title>
+    <link rel="stylesheet" href="../../style.css">
+    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+</head>
+<body>
+    <div id="particles"></div>
+
+    <header>
+        <nav>
+            <a href="/"> <img src="../assets/logo.png" alt="PixelPlugins Logo" class="logo"></a>
+        </nav>
+    </header>
+
+    <main>
+        <div class="policy-content">
+            <h1>🤖 BuildFire AI Chatbot Plugin</h1>
+            <h2>Overview</h2>
+            <p>The AI Chatbot plugin lets you add ChatGPT-powered conversations to your app. To activate it, you'll need your own OpenAI API key.</p>
+
+            <h2>🔑 Generate Your OpenAI API Key</h2>
+            <h3>1. Sign In to OpenAI</h3>
+            <ul>
+                <li>Go to <a href="https://platform.openai.com/">platform.openai.com</a>.</li>
+                <li>Log in or create a new OpenAI account.</li>
+            </ul>
+            <h3>2. Create a New Key</h3>
+            <ul>
+                <li>Click your profile icon in the top-right corner.</li>
+                <li>Select <strong>View API keys</strong>.</li>
+                <li>Click <strong>Create new secret key</strong>.</li>
+                <li>Copy the key &mdash; you won't be able to see it again.</li>
+            </ul>
+
+            <h2>⚙️ Configure the Plugin</h2>
+            <h3>3. Add Your Key in BuildFire</h3>
+            <ul>
+                <li>Open your app in the BuildFire control panel.</li>
+                <li>Launch the AI Chatbot plugin's settings.</li>
+                <li>Paste the key into the <strong>OpenAI API Key</strong> field.</li>
+                <li>Optionally add <strong>Custom Instructions</strong> to guide the assistant.</li>
+                <li>Select a model (e.g., <code>gpt-3.5-turbo</code> or <code>gpt-4o</code>).</li>
+                <li>Click <strong>Save Settings</strong>.</li>
+            </ul>
+
+            <h2>🎨 Design the Chat Experience</h2>
+            <p>In the Design tab you can change the chat title, placeholder text, button label, and colors to match your app's theme. When you're done, click <strong>Save Design Settings</strong>.</p>
+
+            <h2>Security Reminder</h2>
+            <p>Keep your OpenAI key private. If it becomes compromised, delete it on the OpenAI site and create a new one.</p>
+        </div>
+    </main>
+
+    <footer>
+        <div class="footer-links">
+            <a href="/terms-and-conditions">Terms & Conditions</a>
+            <a href="/privacy-policy">Privacy Policy</a>
+            <a href="/return-policy">Return Policy</a>
+        </div>
+        <p>&copy; 2025 PixelPlugins. All rights reserved.</p>
+        <p>San Diego, California</p>
+    </footer>
+
+    <script src="../../main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions for generating an OpenAI API key
- explain where to paste the key and other plugin settings
- highlight design options and security tips

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68584a286950832e934d6937bd7e1a11