### PR TITLE
Fix OpenAI API key instructions

### DIFF
--- a/articles/buildfire-ai-chatbot.html
+++ b/articles/buildfire-ai-chatbot.html
@@ -31,11 +31,11 @@
             </ul>
             <h3>2. Create a New Key</h3>
             <ul>
-                <li>Click your profile icon in the top-right corner.</li>
-                <li>Select <strong>View API keys</strong> (or visit <a href="https://platform.openai.com/settings/organization/api-keys" target="_blank">https://platform.openai.com/settings/organization/api-keys</a>).</li>
+                <li>Click the <strong>Settings</strong> icon in the top-right corner.</li>
+                <li>In the left menu, click <strong><a href="https://platform.openai.com/settings/organization/api-keys" target="_blank">API keys</a></strong>.</li>
                 <li>Choose the organization where you want the key.</li>
                 <li>Click <strong>Create new secret key</strong> in the top right.</li>
-                <li>Select <strong>Owned by you</strong> (tied to your user) or <strong>Service account</strong> (creates a bot member).</li>
+                <li>Select <strong>Owned by you</strong> (ties the key to your personal user) or <strong>Service account</strong> (creates a bot member you can share with teammates or automations).</li>
                 <li>Name the key, pick the project, and copy the key &mdash; you won't be able to see it again.</li>
             </ul>
 


### PR DESCRIPTION
## Summary
- clarify where to find the API keys page in OpenAI settings
- link directly to the API key settings page
- explain the Owned by you vs. Service account options

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68585050de0c832e8a7401cf4eb1e12a