### PR TITLE
style: align why section cards with expertise design

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,18 +89,18 @@
 
         <section id="why" class="why">
             <h2>Why Choose Pixel Plugins?</h2>
-            <div class="why-grid">
-                <div class="why-card">
+            <div class="services-grid">
+                <div class="service-card">
                     <i class="ph ph-trend-up"></i>
                     <h3>Proven Growth</h3>
                     <p>Reduced AWS costs by 30% while improving reliability.</p>
                 </div>
-                <div class="why-card">
+                <div class="service-card">
                     <i class="ph ph-cloud-check"></i>
                     <h3>Zero-Downtime Migrations</h3>
                     <p>Migrated legacy systems to modern cloud platforms with zero downtime.</p>
                 </div>
-                <div class="why-card">
+                <div class="service-card">
                     <i class="ph ph-file-lock"></i>
                     <h3>Audit Confidence</h3>
                     <p>Supported companies through SOC 2 Type I &amp; II audits with no major findings.</p>

--- a/style.css
+++ b/style.css
@@ -165,14 +165,14 @@ h2 {
     color: var(--text-secondary);
 }
 
-.about-grid, .why-grid {
+.about-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 2rem;
     margin-top: 2rem;
 }
 
-.about-card, .why-card {
+.about-card {
     background: var(--surface);
     padding: 2rem;
     border-radius: 15px;
@@ -183,7 +183,7 @@ h2 {
     box-shadow: 0 0 20px rgba(58, 58, 60, 0.2);
 }
 
-.about-card::before, .why-card::before {
+.about-card::before {
     content: '';
     position: absolute;
     top: 0;
@@ -195,26 +195,26 @@ h2 {
     transition: transform 0.3s ease;
 }
 
-.about-card:hover::before, .why-card:hover::before {
+.about-card:hover::before {
     transform: scaleX(1);
 }
 
-.about-card:hover, .why-card:hover {
+.about-card:hover {
     transform: translateY(-5px);
 }
 
-.about-card i, .why-card i {
+.about-card i {
     font-size: 2rem;
     color: var(--primary);
     margin-bottom: 1rem;
 }
 
-.about-card h3, .why-card h3 {
+.about-card h3 {
     margin-bottom: 1rem;
     color: var(--primary);
 }
 
-.about-card p, .why-card p {
+.about-card p {
     color: var(--text-secondary);
 }
 


### PR DESCRIPTION
## Summary
- reuse `service-card` styling for Why Choose Pixel Plugins
- remove obsolete why-specific CSS rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0154d3b808323a2a1f544e8e38548