### PR TITLE
Add client showcase section

### DIFF
--- a/assets/buildfire-logo.svg
+++ b/assets/buildfire-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <text x="0" y="28" font-family="'Inter', sans-serif" font-size="28" fill="#ffffff">Buildfire</text>
+</svg>

--- a/assets/flywheel-logo.svg
+++ b/assets/flywheel-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40">
+  <circle cx="20" cy="20" r="12" fill="#e53935"/>
+  <polygon points="32,8 100,0 86,20 100,40 32,32" fill="#e53935"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -87,6 +87,21 @@
             </div>
         </section>
 
+        <section id="clients" class="clients">
+            <h2>Where We've Worked</h2>
+            <div class="clients-grid">
+                <div class="client-logo">
+                    <img src="assets/flywheel-logo.svg" alt="Flywheel logo">
+                </div>
+                <div class="client-logo">
+                    <img src="assets/buildfire-logo.svg" alt="Buildfire logo">
+                </div>
+                <div class="client-logo">
+                    <img src="assets/shopify-logo.png" alt="Shopify logo">
+                </div>
+            </div>
+        </section>
+
         <section id="why" class="why">
             <h2>Why Choose Pixel Plugins?</h2>
             <div class="services-grid">

--- a/style.css
+++ b/style.css
@@ -310,6 +310,30 @@ h2 {
     color: var(--text-secondary);
 }
 
+.clients {
+    text-align: center;
+}
+
+.clients-grid {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 4rem;
+    flex-wrap: wrap;
+    margin-top: 3rem;
+}
+
+.client-logo img {
+    height: 60px;
+    opacity: 0.8;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.client-logo img:hover {
+    transform: scale(1.1);
+    opacity: 1;
+}
+
 .contact {
     background: var(--surface);
     border-radius: 15px;


### PR DESCRIPTION
## Summary
- Showcase Flywheel, Buildfire, and Shopify clients in a new "Where We've Worked" section.
- Style client logos with responsive flex layout and hover effects.
- Add simple SVG logo assets for Flywheel and Buildfire.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a01aba12b88323ae2c67983c03e1b1