### PR TITLE
fix: constrain client logo sizes

### DIFF
--- a/style.css
+++ b/style.css
@@ -324,7 +324,10 @@ h2 {
 }
 
 .client-logo img {
-    height: 60px;
+    max-height: 60px;
+    max-width: 200px;
+    width: auto;
+    height: auto;
     opacity: 0.8;
     transition: transform 0.3s ease, opacity 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- limit client logo dimensions for more consistent layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02060afe08323975db873acbfdb97