### PR TITLE
Remove Pixel Plugins tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
                     <p>Secure, future-ready infrastructure that grows with you.</p>
                 </div>
             </div>
-            <p class="tagline">🚀 Pixel Plugins — Scalable. Secure. Future-ready.</p>
         </section>
 
         <section id="contact" class="contact">


### PR DESCRIPTION
## Summary
- remove marketing tagline from homepage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a02ce966208323ae94a6ef7a647842