### PR TITLE
Update Buildfire chatbot article links

### DIFF
--- a/articles/buildfire-ai-chatbot.html
+++ b/articles/buildfire-ai-chatbot.html
@@ -56,7 +56,7 @@
             <h3>4. Create an OpenAI Vector Store (Optional)</h3>
             <p>OpenAI Vector Store is a hosted file search feature that lets the model search your uploaded files for relevant information before it responds. This is useful when you want your chatbot to answer questions using your own documents instead of only relying on custom instructions.</p>
             <ul>
-                <li>Sign in to your OpenAI dashboard at <a href="https://platform.openai.com/" target="_blank">platform.openai.com</a>.</li>
+                <li>Sign in to your OpenAI <a href="https://platform.openai.com/" target="_blank" rel="noopener noreferrer">dashboard</a>.</li>
                 <li>In the left sidebar, go to <strong>Storage</strong> under the <strong>Manage</strong> section.</li>
                 <li>Open the <strong>Vector stores</strong> tab.</li>
                 <li>Click <strong>Create</strong> to make a new vector store.</li>
@@ -64,7 +64,7 @@
                 <li>Copy the vector store ID from the details panel. It starts with <code>vs_</code>.</li>
                 <li>Return to the BuildFire control panel, choose <strong>OpenAI Vector Store</strong>, and paste that ID into the <strong>OpenAI Vector Store ID</strong> field.</li>
             </ul>
-            <p>You can manage your vector stores directly in OpenAI here: <a href="https://platform.openai.com/storage/vector_stores" target="_blank">platform.openai.com/storage/vector_stores</a>.</p>
+            <p>You can manage your vector stores directly in OpenAI <a href="https://platform.openai.com/storage/vector_stores" target="_blank" rel="noopener noreferrer">here</a>.</p>
 
             <h2>🎨 Design the Chat Experience</h2>
             <p>In the Design tab you can change the chat title, placeholder text, button label, and colors to match your app's theme. When you're done, click <strong>Save Design Settings</strong>.</p>


### PR DESCRIPTION
### Motivation
- Make the OpenAI references in the Buildfire AI chatbot article more user-friendly by replacing raw URLs with descriptive, clickable anchor text that opens in a new tab and follow safe external linking practices.

### Description
- Replaced the inline platform URL with a clickable `dashboard` link and replaced the raw vector stores URL with a clickable `here` link in `articles/buildfire-ai-chatbot.html`.
- Added `target="_blank"` and `rel="noopener noreferrer"` to both external links for safer new-tab behavior.

### Testing
- Searched the repository for occurrences and confirmed the two target instances were updated using `rg` and file inspection, which succeeded.
- Inspected the modified file snippet in `articles/buildfire-ai-chatbot.html` to verify the anchor text, target, and `rel` attributes were applied, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb39a846d4832ea9427de8849467ab)