### PR TITLE
Add Open Graph and Twitter Card meta tags

### DIFF
--- a/articles/buildfire-ai-chatbot.html
+++ b/articles/buildfire-ai-chatbot.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BuildFire AI Chatbot API Key Setup | PixelPlugins</title>
+    <meta name="description" content="Step-by-step guide to setting up your AI Chatbot API key in BuildFire — by Pixel Plugins.">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="BuildFire AI Chatbot API Key Setup | Pixel Plugins">
+    <meta property="og:description" content="Step-by-step guide to setting up your AI Chatbot API key in BuildFire — by Pixel Plugins.">
+    <meta property="og:url" content="https://pixelplugins.com/articles/buildfire-ai-chatbot.html">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="BuildFire AI Chatbot API Key Setup | Pixel Plugins">
+    <meta name="twitter:description" content="Step-by-step guide to setting up your AI Chatbot API key in BuildFire — by Pixel Plugins.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">

--- a/articles/hipaa-dynamic-form-builder.html
+++ b/articles/hipaa-dynamic-form-builder.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dynamic Form Builder | PixelPlugins</title>
+    <meta name="description" content="A HIPAA-ready dynamic form builder plugin for BuildFire — built by Pixel Plugins.">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="Dynamic Form Builder | Pixel Plugins">
+    <meta property="og:description" content="A HIPAA-ready dynamic form builder plugin for BuildFire — built by Pixel Plugins.">
+    <meta property="og:url" content="https://pixelplugins.com/articles/hipaa-dynamic-form-builder.html">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Dynamic Form Builder | Pixel Plugins">
+    <meta name="twitter:description" content="A HIPAA-ready dynamic form builder plugin for BuildFire — built by Pixel Plugins.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pixel Plugins — Scalable Software, AI Solutions & Custom Plugins</title>
+    <meta name="description" content="Modern SaaS architecture, audit-ready compliance, and intelligent plugins — all crafted for growth.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="Pixel Plugins — Scalable Software, AI Solutions & Custom Plugins">
+    <meta property="og:description" content="Modern SaaS architecture, audit-ready compliance, and intelligent plugins — all crafted for growth.">
+    <meta property="og:url" content="https://pixelplugins.com/">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Pixel Plugins — Scalable Software, AI Solutions & Custom Plugins">
+    <meta name="twitter:description" content="Modern SaaS architecture, audit-ready compliance, and intelligent plugins — all crafted for growth.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy | PixelPlugins</title>
+    <meta name="description" content="Read the Pixel Plugins privacy policy — how we collect, use, and protect your data.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="Privacy Policy | Pixel Plugins">
+    <meta property="og:description" content="Read the Pixel Plugins privacy policy — how we collect, use, and protect your data.">
+    <meta property="og:url" content="https://pixelplugins.com/privacy-policy/">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Privacy Policy | Pixel Plugins">
+    <meta name="twitter:description" content="Read the Pixel Plugins privacy policy — how we collect, use, and protect your data.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">

--- a/return-policy/index.html
+++ b/return-policy/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Return Policy | PixelPlugins</title>
+    <meta name="description" content="Read the Pixel Plugins return policy — our terms for refunds and returns.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="Return Policy | Pixel Plugins">
+    <meta property="og:description" content="Read the Pixel Plugins return policy — our terms for refunds and returns.">
+    <meta property="og:url" content="https://pixelplugins.com/return-policy/">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Return Policy | Pixel Plugins">
+    <meta name="twitter:description" content="Read the Pixel Plugins return policy — our terms for refunds and returns.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">

--- a/shopify-showcase/index.html
+++ b/shopify-showcase/index.html
@@ -5,6 +5,19 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Shopify Loyalty Integration by PixelPlugins</title>
+  <meta name="description" content="See how Pixel Plugins built a seamless Shopify loyalty integration — connecting your store to powerful rewards in minutes.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Pixel Plugins">
+  <meta property="og:title" content="Shopify Loyalty Integration by Pixel Plugins">
+  <meta property="og:description" content="See how Pixel Plugins built a seamless Shopify loyalty integration — connecting your store to powerful rewards in minutes.">
+  <meta property="og:url" content="https://pixelplugins.com/shopify-showcase/">
+  <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+  <meta property="og:image:width" content="512">
+  <meta property="og:image:height" content="512">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Shopify Loyalty Integration by Pixel Plugins">
+  <meta name="twitter:description" content="See how Pixel Plugins built a seamless Shopify loyalty integration — connecting your store to powerful rewards in minutes.">
+  <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
   <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">

--- a/terms-and-conditions/index.html
+++ b/terms-and-conditions/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms and Conditions | PixelPlugins</title>
+    <meta name="description" content="Read the Pixel Plugins terms and conditions — the rules governing use of our services.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Pixel Plugins">
+    <meta property="og:title" content="Terms and Conditions | Pixel Plugins">
+    <meta property="og:description" content="Read the Pixel Plugins terms and conditions — the rules governing use of our services.">
+    <meta property="og:url" content="https://pixelplugins.com/terms-and-conditions/">
+    <meta property="og:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Terms and Conditions | Pixel Plugins">
+    <meta name="twitter:description" content="Read the Pixel Plugins terms and conditions — the rules governing use of our services.">
+    <meta name="twitter:image" content="https://pixelplugins.com/assets/brand/pixel-appicon-512.png">
     <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/assets/brand/favicon-32.png" sizes="32x32" type="image/png">
     <link rel="icon" href="/assets/brand/favicon-16.png" sizes="16x16" type="image/png">


### PR DESCRIPTION
## Summary

- Adds `og:title`, `og:description`, `og:image`, `og:url`, `og:type`, `og:site_name` to all 7 pages
- Adds `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` to all 7 pages
- Adds `meta name="description"` to all pages (was missing entirely)
- Uses `pixel-appicon-512.png` as the preview image across all pages

## Result

Sharing any page on WhatsApp, iMessage, Twitter, LinkedIn etc. will now show a proper preview card with the Pixel Plugins icon, page title, and description.

> **Note:** For the best wide-format preview (especially on Twitter/LinkedIn), consider creating a 1200×630px social banner image and swapping it in as `og:image`.

## Test plan

- [ ] Share homepage URL in WhatsApp — preview card appears with icon + title + description
- [ ] Test with [opengraph.xyz](https://www.opengraph.xyz) or Facebook Sharing Debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)